### PR TITLE
Add Rooftop Ruby + map link

### DIFF
--- a/content/events/index.md
+++ b/content/events/index.md
@@ -17,7 +17,8 @@ To include your event, please [click this link](https://github.com/mperham/blog/
 
 ## Tuesday 11/14
 
-* **Board Game Night** - 7-10pm, T&C Resort: Flamingo Lawn area - Bring your favorite game!
+* **Board Game Night** - 7-10pm, T&C Resort: Flamingo Lawn area - Bring your favorite game! (see [map](https://www.towncountry.com/discover/hotel-map))
+* **Rooftop Ruby Event** - 6-9pm, T&C Resort: Lower Lawn of Monkey Bar (see [map](https://www.towncountry.com/discover/hotel-map))
 
 ## Wednesday 11/15
 


### PR DESCRIPTION
Adding the Rooftop Ruby event - will ping the hosts to figure out the exact times